### PR TITLE
Multi thread support for compression

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -58,6 +58,20 @@ MD2ROFF_FLAGS = --roff --warnings --manual="User Commands" --organization="lz4 $
 
 include ../Makefile.inc
 
+ENABLE_MT := no
+ifeq ($(ENABLE_MT),yes)
+SRCFILES_MT := $(SRCFILES:lz4io.c=lz4iomt.cpp)
+OBJFILES_MT := $(OBJFILES:lz4io.o=lz4iomt.o)
+CPPFLAGS += -DLZ4IO_USE_MT
+LZ4_CC := $(CXX) $(FLAGS) $(CXXFLAGS) -pthread
+lz4iomt.o: lz4iomt.cpp lz4io.c
+	$(LZ4_CC) -c lz4iomt.cpp -o $@
+else
+SRCFILES_MT := $(SRCFILES)
+OBJFILES_MT := $(OBJFILES)
+LZ4_CC := $(CC) $(FLAGS)
+endif
+
 default: lz4-release
 
 all: lz4 lz4c
@@ -78,11 +92,11 @@ lz4-exe.rc: lz4-exe.rc.in
 lz4-exe.o: lz4-exe.rc
 	$(WINDRES) -i lz4-exe.rc -o lz4-exe.o
 
-lz4: $(OBJFILES) lz4-exe.o
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+lz4: $(OBJFILES_MT) lz4-exe.o
+	$(LZ4_CC) $^ -o $@$(EXT)
 else
-lz4: $(OBJFILES)
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+lz4: $(OBJFILES_MT)
+	$(LZ4_CC) $^ -o $@$(EXT)
 endif
 
 
@@ -93,8 +107,8 @@ lz4c: lz4
 	$(LN_SF) lz4$(EXT) lz4c$(EXT)
 
 lz4c32: CFLAGS += -m32
-lz4c32 : $(SRCFILES)
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+lz4c32 : $(SRCFILES_MT)
+	$(LZ4_CC) $^ -o $@$(EXT)
 
 lz4.1: lz4.1.md $(LIBVER_SRC)
 	cat $< | $(MD2ROFF) $(MD2ROFF_FLAGS) | sed -n '/^\.\\\".*/!p' > $@

--- a/programs/lz4iomt.cpp
+++ b/programs/lz4iomt.cpp
@@ -1,0 +1,106 @@
+/*
+  LZ4iomt.cpp - LZ4 File/Stream Interface with multi thread support
+  Copyright (C) yumeyao 2020
+  GPL v2 License
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  You can contact the author at :
+  - LZ4 source repository : https://github.com/lz4/lz4
+  - LZ4 public forum : https://groups.google.com/forum/#!forum/lz4c
+*/
+/*
+  Note : this is stand-alone program.
+  It is not part of LZ4 compression library, it is a user code of the LZ4 library.
+  - The license of LZ4 library is BSD.
+  - The license of xxHash library is BSD.
+  - The license of this source file is GPLv2.
+*/
+
+#include <thread>
+extern "C" {
+#include "lz4io.c"
+}
+
+static unsigned parallel = 0;
+
+void LZ4IO_setParallel(unsigned n) {
+    parallel = n;
+}
+
+static unsigned LZ4IO_getAvailableCores() {
+    unsigned n = std::thread::hardware_concurrency();
+    return n > 0 ? n : 1;
+}
+
+int LZ4IO_multiThreadAvailable() {
+    if (parallel == 0)
+    {
+        parallel = LZ4IO_getAvailableCores();
+    }
+    return parallel - 1;
+}
+
+unsigned long long LZ4IO_compressFilename_extRess_multithread(const cRess_t* pRess, FILE* srcFile, const char* srcFileName, FILE* dstFile,
+                                                              const LZ4F_preferences_t* pPrefs, unsigned long long* pCompressedfilesize)
+{
+    DISPLAYLEVEL(4, "Using Multithread mode\n");
+    void* const srcBuffer = pRess->srcBuffer;
+    size_t blockSize = pRess->srcBufferSize;
+    void* const dstBuffer = pRess->dstBuffer;
+    const size_t dstBufferSize = pRess->dstBufferSize;
+    LZ4F_compressionContext_t ctx = pRess->ctx;   /* just a pointer */
+    unsigned long long compressedfilesize = 0;
+    size_t readSize = blockSize;
+    unsigned long long filesize = readSize;
+
+    /* Write Archive Header */
+    size_t headerSize = LZ4F_compressBegin_usingCDict(ctx, dstBuffer, dstBufferSize, pRess->cdict, pPrefs);
+    if (LZ4F_isError(headerSize)) EXM_THROW(33, "File header generation failed : %s", LZ4F_getErrorName(headerSize));
+    { size_t const sizeCheck = fwrite(dstBuffer, 1, headerSize, dstFile);
+        if (sizeCheck!=headerSize) EXM_THROW(34, "Write error : cannot write header"); }
+    compressedfilesize += headerSize;
+
+    /* Main Loop */
+    while (readSize>0) {
+        size_t outSize;
+
+        /* Compress Block */
+        outSize = LZ4F_compressUpdate(ctx, dstBuffer, dstBufferSize, srcBuffer, readSize, NULL);
+        if (LZ4F_isError(outSize)) EXM_THROW(35, "Compression failed : %s", LZ4F_getErrorName(outSize));
+        compressedfilesize += outSize;
+        DISPLAYUPDATE(2, "\rRead : %u MB   ==> %.2f%%   ", (unsigned)(filesize>>20), (double)compressedfilesize/filesize*100);
+
+        /* Write Block */
+        { size_t const sizeCheck = fwrite(dstBuffer, 1, outSize, dstFile);
+            if (sizeCheck!=outSize) EXM_THROW(36, "Write error : cannot write compressed block"); }
+
+        /* Read next block */
+        readSize  = fread(srcBuffer, (size_t)1, (size_t)blockSize, srcFile);
+        filesize += readSize;
+    }
+    if (ferror(srcFile)) EXM_THROW(37, "Error reading %s ", srcFileName);
+
+    /* End of Stream mark */
+    headerSize = LZ4F_compressEnd(ctx, dstBuffer, dstBufferSize, NULL);
+    if (LZ4F_isError(headerSize)) EXM_THROW(38, "End of file generation failed : %s", LZ4F_getErrorName(headerSize));
+
+    { size_t const sizeCheck = fwrite(dstBuffer, 1, headerSize, dstFile);
+        if (sizeCheck!=headerSize) EXM_THROW(39, "Write error : cannot write end of stream"); }
+    compressedfilesize += headerSize;
+
+    *pCompressedfilesize = compressedfilesize;
+    return filesize;
+}

--- a/programs/lz4iomt.cpp
+++ b/programs/lz4iomt.cpp
@@ -30,9 +30,15 @@
 */
 
 #include <thread>
+#include <condition_variable>
+#include <vector>
+#include <deque>
+#include <utility>
 extern "C" {
 #include "lz4io.c"
 }
+#define XXH_STATIC_LINKING_ONLY
+#include "xxhash.h"
 
 static unsigned parallel = 0;
 
@@ -53,54 +59,260 @@ int LZ4IO_multiThreadAvailable() {
     return parallel - 1;
 }
 
+namespace LZ4IOMT {
+
+struct LZ4IOHandler {
+    virtual size_t write(const void* buffer, size_t size) = 0;
+    virtual size_t read(void* buffer, size_t size) = 0;
+    virtual const char* readError() = 0;
+    virtual ~LZ4IOHandler() {}
+};
+
+struct LZ4IOFileInfo {
+    FILE* srcFile;
+    const char* srcFileName;
+    FILE* dstFile;
+};
+
+struct LZ4IOFileHandler : LZ4IOHandler, LZ4IOFileInfo {
+    LZ4IOFileHandler(const LZ4IOFileInfo& info) : LZ4IOFileInfo(info) {}
+    size_t write(const void* buffer, size_t size) override { return fwrite(buffer, 1, size, dstFile); }
+    size_t read(void* buffer, size_t size) override { return fread(buffer, 1, size, srcFile); }
+    const char* readError() override { return ferror(srcFile) ? srcFileName : nullptr; }
+};
+
+struct WorkCtx {
+    WorkCtx(LZ4IOHandler& info, const cRess_t* pRess, const LZ4F_preferences_t* pPrefs, unsigned nThreads) 
+        : io(info), compressedFileSize(0), contentSize(pPrefs->frameInfo.contentSize), blockSize(pRess->srcBufferSize)
+        , dstBufferSize(pRess->dstBufferSize), prefs(*pPrefs), contentChecksumFlag(pPrefs->frameInfo.contentChecksumFlag)
+    {
+        void* const dstBuffer = pRess->dstBuffer;
+
+        /* Write Archive Header */
+        size_t headerSize = LZ4F_compressBegin_usingCDict(pRess->ctx, pRess->dstBuffer, dstBufferSize, pRess->cdict, pPrefs);
+        if (LZ4F_isError(headerSize)) EXM_THROW(33, "File header generation failed : %s", LZ4F_getErrorName(headerSize));
+        { size_t const sizeCheck = io.write(dstBuffer, headerSize);
+            if (sizeCheck!=headerSize) EXM_THROW(34, "Write error : cannot write header"); }
+
+        compressedFileSize += headerSize;
+        prefs.frameInfo.contentSize = 0;
+        prefs.frameInfo.contentChecksumFlag = LZ4F_noContentChecksum;
+
+        contentSize = doWork(pRess->srcBuffer, pRess->dstBuffer, nThreads);
+    }
+    unsigned long long getCompressedFileSize() const { return compressedFileSize; }
+    unsigned long long getContentSize() const { return contentSize; }
+private:
+    LZ4IOHandler& io;
+    unsigned long long compressedFileSize;
+    unsigned long long contentSize;
+    size_t blockSize;
+    size_t dstBufferSize;
+    LZ4F_preferences_t prefs;
+    LZ4F_contentChecksum_t contentChecksumFlag;
+
+    struct Block {
+        void* src;
+        void* dst;
+        unsigned srcSize;
+        unsigned dstSize;
+    };
+
+    std::deque<Block> blocks;
+    std::vector<Block*> pendingBlocks;
+    std::condition_variable cv_compress;
+    std::condition_variable cv_writeback;
+    std::mutex mtx;
+    // std::vector<void*> freeSrcBuffers;
+    // std::vector<void*> freeDstBuffers;
+
+    unsigned state;
+    enum { SOURCE_EOF = 1 };
+    bool isEOF() const { return state & SOURCE_EOF; }
+    void setEOF() {
+        state |= SOURCE_EOF;
+        std::unique_lock<std::mutex> lock(mtx);
+        cv_compress.notify_all();
+    }
+    Block* getPendingBlock() { //blocking call
+        std::unique_lock<std::mutex> lock(mtx);
+        cv_writeback.notify_one(); // notify some compression is done
+        if (pendingBlocks.empty() && isEOF()) return nullptr;
+        cv_compress.wait(lock, [this]() {
+            return !pendingBlocks.empty() || isEOF();
+        });
+        if (!pendingBlocks.empty()) {
+            Block* p = pendingBlocks[0];
+            pendingBlocks.erase(pendingBlocks.begin());
+            return p;
+        }
+        // is EOF
+        return 0;
+    }
+    void pushPendingBlock(Block& block) { std::lock_guard<std::mutex> _(mtx); pendingBlocks.push_back(&block); cv_compress.notify_one(); }
+    void* getDstBuffer() { return malloc(dstBufferSize); }
+    void* getSrcBuffer() { return malloc(blockSize); }
+
+    struct ThreadArg {
+        WorkCtx* workCtx;
+        Block* initialBlock;
+    };
+
+    void worker(Block* initialBlock);
+    static void workerThread(void* arg);
+    unsigned long long doWork(void* firstSrc, void* firstDst, unsigned nThreads);
+
+    void freeBuffer(void* p) { free(p); }
+    void freeBuffer(void* p, void* nofreeAddress) { if (p != nofreeAddress) free(p); }
+};
+
+static unsigned getFrameHeaderSize(const LZ4F_preferences_t& prefs) {
+    return 7
+        //+ (prefs.frameInfo.contentSize ? 8 : 0) // always 0
+        + (prefs.frameInfo.dictID ? 4 : 0);
+}
+
+inline void WorkCtx::worker(Block* block) {
+    do {
+        block->dst = block->dst ? block->dst : getDstBuffer();
+        size_t outSize = LZ4F_compressFrame(block->dst, dstBufferSize, block->src, block->srcSize, &prefs);
+        if (LZ4F_isError(outSize)) EXM_THROW(35, "Compression failed : %s", LZ4F_getErrorName(outSize));
+        block->dstSize = (unsigned)outSize;
+    } while ((block = getPendingBlock()));
+}
+
+void WorkCtx::workerThread(void* arg_) {
+    ThreadArg& arg = *static_cast<ThreadArg*>(arg_);
+    arg.workCtx->worker(arg.initialBlock);
+}
+
+unsigned long long WorkCtx::doWork(void* firstSrc, void* firstDst, unsigned nThreads) {
+    std::vector<std::pair<std::thread, ThreadArg>> threads;
+    threads.reserve(nThreads);
+
+    unsigned long long blockIndex = 0;
+    unsigned long long finishedBlock = 0;
+    unsigned long long hashedBlock = 0;
+
+    void* src = firstSrc;
+    void* dst = firstDst;
+    unsigned srcSize = blockSize;
+
+    state = 0;
+    XXH32_state_t xxh;
+    if (contentChecksumFlag) XXH32_reset(&xxh, 0);
+
+    auto needMoreBlocks = [&]() { return !isEOF() && blocks.size() < 2 * nThreads; };
+
+    while (true) {
+        if (needMoreBlocks()) {
+            if (blockIndex > 0) {
+                src = getSrcBuffer();
+                size_t size = io.read(src, blockSize);
+                if (size < blockSize) {
+                    const char *srcFileName = io.readError();
+                    if (srcFileName) EXM_THROW(37, "Error reading %s ", srcFileName);
+                    setEOF();
+                }
+                srcSize = size;
+                if (size == 0) {
+                    freeBuffer(src);
+                    continue;
+                }
+                dst = nullptr;
+            }
+
+            blocks.emplace_back(Block{src, dst, srcSize, (unsigned)0});
+            ++blockIndex;
+
+            if (blockIndex <= nThreads) {
+                threads.emplace_back();
+                threads.back().second = { this, &blocks.back() };
+                threads.back().first = std::thread(workerThread, &threads.back().second);
+                if (blocks.front().dstSize == 0) continue; // feed more source blocks
+            }
+            else {
+                pushPendingBlock(blocks.back());
+            }
+        }
+        else {
+            if (isEOF() && finishedBlock == blockIndex) break;
+        }
+
+        while (!blocks.empty()) {
+            if (blocks.front().dstSize != 0) {
+                Block& block = blocks.front();
+                unsigned headerSize = getFrameHeaderSize(prefs);
+                unsigned writeSize = block.dstSize - headerSize - 4;
+                size_t result = io.write(((char*)block.dst) + headerSize, writeSize);
+                if (result < writeSize) EXM_THROW(36, "Write error : cannot write compressed block");
+                compressedFileSize += writeSize;
+                if (contentChecksumFlag && finishedBlock == hashedBlock) {
+                    (void)XXH32_update(&xxh, block.src, block.srcSize);
+                    ++hashedBlock;
+                }
+                ++finishedBlock;
+                freeBuffer(block.src, firstSrc);
+                freeBuffer(block.dst, firstDst);
+                unsigned lastchunkSize = block.srcSize;
+                blocks.pop_front();
+                if (blocks.empty() || blocks.front().dstSize == 0) {
+                    unsigned long long filesize = (finishedBlock - 1) * blockSize + lastchunkSize;
+                    DISPLAYUPDATE(2, "\rRead : %u MB   ==> %.2f%%   ", (unsigned)(filesize>>20), (double)compressedFileSize/filesize*100);
+                }
+                continue;
+            }
+            if (needMoreBlocks()) {
+                break;
+            }
+            if (contentChecksumFlag) {
+                for (auto iter = blocks.begin() + (hashedBlock - finishedBlock); iter != blocks.end(); ++iter) {
+                    auto& block = *iter;
+                    (void)XXH32_update(&xxh, block.src, block.srcSize);
+                    ++hashedBlock;
+                    if (blocks.front().dstSize != 0) break;
+                }
+                if (blocks.front().dstSize != 0) continue;
+            }
+            std::unique_lock<std::mutex> lock(mtx);
+            cv_writeback.wait(lock, [this]() {
+                return blocks.front().dstSize != 0;
+            });
+        }
+    };
+
+    unsigned long long readSize = (finishedBlock - 1) * blockSize + srcSize;
+    {
+        if (contentSize != 0 && contentSize != readSize) EXM_THROW(38, "End of file generation failed : %s", LZ4F_getErrorName(LZ4F_errorCode_t(0) - LZ4F_ERROR_frameSize_wrong));
+
+        char frameend[8] = {0};
+        size_t writeSize = 4;
+        if (contentChecksumFlag) {
+            U32 const checksum = XXH32_digest(&xxh);
+            LZ4IO_writeLE32(&frameend[4], checksum);
+            writeSize = 8;
+        }
+        size_t result = io.write(frameend, writeSize);
+        if (result < writeSize) EXM_THROW(39, "Write error : cannot write end of stream");
+        compressedFileSize += writeSize;
+    }
+    for (auto&& thread : threads) thread.first.join();
+    return readSize;
+}
+
+
+
+}
+
+
 unsigned long long LZ4IO_compressFilename_extRess_multithread(const cRess_t* pRess, FILE* srcFile, const char* srcFileName, FILE* dstFile,
                                                               const LZ4F_preferences_t* pPrefs, unsigned long long* pCompressedfilesize)
 {
     DISPLAYLEVEL(4, "Using Multithread mode\n");
-    void* const srcBuffer = pRess->srcBuffer;
-    size_t blockSize = pRess->srcBufferSize;
-    void* const dstBuffer = pRess->dstBuffer;
-    const size_t dstBufferSize = pRess->dstBufferSize;
-    LZ4F_compressionContext_t ctx = pRess->ctx;   /* just a pointer */
-    unsigned long long compressedfilesize = 0;
-    size_t readSize = blockSize;
-    unsigned long long filesize = readSize;
 
-    /* Write Archive Header */
-    size_t headerSize = LZ4F_compressBegin_usingCDict(ctx, dstBuffer, dstBufferSize, pRess->cdict, pPrefs);
-    if (LZ4F_isError(headerSize)) EXM_THROW(33, "File header generation failed : %s", LZ4F_getErrorName(headerSize));
-    { size_t const sizeCheck = fwrite(dstBuffer, 1, headerSize, dstFile);
-        if (sizeCheck!=headerSize) EXM_THROW(34, "Write error : cannot write header"); }
-    compressedfilesize += headerSize;
+    LZ4IOMT::LZ4IOFileHandler ioInfo = LZ4IOMT::LZ4IOFileInfo{srcFile, srcFileName, dstFile};
+    LZ4IOMT::WorkCtx workers(ioInfo, pRess, pPrefs, parallel);
 
-    /* Main Loop */
-    while (readSize>0) {
-        size_t outSize;
-
-        /* Compress Block */
-        outSize = LZ4F_compressUpdate(ctx, dstBuffer, dstBufferSize, srcBuffer, readSize, NULL);
-        if (LZ4F_isError(outSize)) EXM_THROW(35, "Compression failed : %s", LZ4F_getErrorName(outSize));
-        compressedfilesize += outSize;
-        DISPLAYUPDATE(2, "\rRead : %u MB   ==> %.2f%%   ", (unsigned)(filesize>>20), (double)compressedfilesize/filesize*100);
-
-        /* Write Block */
-        { size_t const sizeCheck = fwrite(dstBuffer, 1, outSize, dstFile);
-            if (sizeCheck!=outSize) EXM_THROW(36, "Write error : cannot write compressed block"); }
-
-        /* Read next block */
-        readSize  = fread(srcBuffer, (size_t)1, (size_t)blockSize, srcFile);
-        filesize += readSize;
-    }
-    if (ferror(srcFile)) EXM_THROW(37, "Error reading %s ", srcFileName);
-
-    /* End of Stream mark */
-    headerSize = LZ4F_compressEnd(ctx, dstBuffer, dstBufferSize, NULL);
-    if (LZ4F_isError(headerSize)) EXM_THROW(38, "End of file generation failed : %s", LZ4F_getErrorName(headerSize));
-
-    { size_t const sizeCheck = fwrite(dstBuffer, 1, headerSize, dstFile);
-        if (sizeCheck!=headerSize) EXM_THROW(39, "Write error : cannot write end of stream"); }
-    compressedfilesize += headerSize;
-
-    *pCompressedfilesize = compressedfilesize;
-    return filesize;
+    *pCompressedfilesize = workers.getCompressedFileSize();
+    return workers.getContentSize();
 }

--- a/programs/lz4iomt.h
+++ b/programs/lz4iomt.h
@@ -1,0 +1,79 @@
+/*
+  LZ4iomt.h - LZ4 File/Stream Interface with multi thread support
+  Copyright (C) yumeyao 2020
+  GPL v2 License
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  You can contact the author at :
+  - LZ4 source repository : https://github.com/lz4/lz4
+  - LZ4 public forum : https://groups.google.com/forum/#!forum/lz4c
+*/
+/*
+  Note : this is stand-alone program.
+  It is not part of LZ4 compression library, it is a user code of the LZ4 library.
+  - The license of LZ4 library is BSD.
+  - The license of xxHash library is BSD.
+  - The license of this source file is GPLv2.
+*/
+
+#ifndef LZ4IOMT_H_967887017
+#define LZ4IOMT_H_967887017
+
+#include <stdio.h>     /* fprintf, fopen, fread, stdin, stdout, fflush, getchar, FILE */
+#define LZ4F_STATIC_LINKING_ONLY
+#include "lz4frame.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    void*  srcBuffer;
+    size_t srcBufferSize;
+    void*  dstBuffer;
+    size_t dstBufferSize;
+    LZ4F_compressionContext_t ctx;
+    LZ4F_CDict* cdict;
+} cRess_t;
+
+/*
+ * parallel = 0 : use all (logical) cores, each core has a worker thread
+ * parallel = 1 : disable multithread
+ * parallel = X : use X threads
+ */
+void LZ4IO_setParallel(unsigned parallel);
+int LZ4IO_multiThreadAvailable();
+
+static int LZ4IO_compressUseMultiThread(const LZ4F_CDict* cdict, const LZ4F_preferences_t* prefsPtr) {
+    return
+        (cdict == NULL) && prefsPtr->frameInfo.dictID == 0 &&
+        prefsPtr->frameInfo.blockMode == LZ4F_blockIndependent &&
+        LZ4IO_multiThreadAvailable();
+}
+
+/*
+ * LZ4IO_compressFilename_extRess_multiBlocks()
+ * result : filesize
+ */
+unsigned long long LZ4IO_compressFilename_extRess_multithread(const cRess_t* pRess, FILE* srcFile, const char* srcFileName, FILE* dstFile,
+                                                              const LZ4F_preferences_t* pPrefs, unsigned long long* pCompressedfilesize);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* LZ4IOMT_H_967887017 */

--- a/programs/lz4iomt.h
+++ b/programs/lz4iomt.h
@@ -33,12 +33,13 @@
 #define LZ4IOMT_H_967887017
 
 #include <stdio.h>     /* fprintf, fopen, fread, stdin, stdout, fflush, getchar, FILE */
-#define LZ4F_STATIC_LINKING_ONLY
-#include "lz4frame.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define LZ4F_STATIC_LINKING_ONLY
+#include "lz4frame.h"
 
 typedef struct {
     void*  srcBuffer;


### PR DESCRIPTION
# LZ4 CLI with multi-thread compression support

### Overview

There are already 2 other implementation with multi-thread support mentioned @ https://lz4.github.io/lz4/. But they're not good enough to be used as a _**transparent**_ replacement of the original lz4 CLI.

- **[C++11 multi-threads](https://github.com/t-mat/lz4mt)** by Takayuki Matsuoka.
  It re-implemented lz4 using C++ based on an ancient version of lz4, so it's difficult to either verify its correctness or apply latests lz4 changes(optimizations) into it.
  **Furthermore, its implementation is broken.**
  - unprotected concurrent `vector<future>` access and `push_back()` which may lead to crash
  - inefficient thread model which requires reading the whole file therefore requires allocating as big as the file memory for source buffer
- **[7Zip with LZ4](https://github.com/mcmilk/7-Zip-zstd)** or **[zstdmt](https://github.com/mcmilk/zstdmt)** by Tino Reichardt
  This is a much better version, based on latest lz4 and being actively maintained. But its output is different from that of original lz4. Though I tried decompressing it using the stock lz4 and it worked, it may fail on some other lz4 implementations.
  - The official lz4 compress a file into a **single** _stream_ that contains **multiple** _blocks._
  - zstdmt compress a file into **multiple** _streams_, each contains **one** _block._
    Furthermore, zstdmt uses [skippable streams](https://github.com/mcmilk/7-Zip-zstd/issues/105). Which could result in incompatibility with 3rd party implentation and [file header detection failure](https://github.com/mcmilk/7-Zip-zstd/issues/102)

  There're more:
  - it doesn't support checksum, which provides a baseline data corruption check.
  - its thread model doesn't prefetch input at all.
  - It has a slightly different CLI tool syntax, if you're concerned.

Therefore, I modified from the lz4 source to enable multi-thread compression (decompression is likely to be I/O bounded so parallel means nothing).

### Features
- Multi-thread compression
  - using C++11 std::thread and related synchronization primitives
- Fully compatible with stock lz4
- lz4 lib is not touched. only lz4cli is modified.
- C+11 compatible with MT on, C90 compatible with MT off

### Limits
- lack of dictionary support (fall back to single thread compression), see #2 for further discussion
- lack of block-dependent support (fall back to single thread compression), see #3 for further discussion

### Build & Install
make ENABLE_MT=yes
make install

### Other Notes
The way how this compresses in parellel is kind of hackish. It actually compresses each block into one stream (like what zstdmt does), but it then trims the stream into a block by removing headers, making the output identical to the official lz4.

The reason of such hackish way is, there is no available block-level apis in lz4lib. In order to do it in a non-hackish way, lz4frame needs to be refactored significantly.